### PR TITLE
Corrects need help btn behavior in Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-link",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-link",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "React component that helps to track clicks for links",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Ticket: https://trello.com/c/heJ3HcYI/3273-need-help-button-to-faq-page-gets-blocked-by-safari

This fixes the issue where the 'Need Help' button that goes to our FAQ gets blocked by the Safari browser. Safari blocks any `window.open()` calls made in an async call. The workaround is to create a reference to `window.open()` and then provide the reference with a location/url once the async call resolves. Read more [here](https://stackoverflow.com/questions/20696041/window-openurl-blank-not-working-on-imac-safari). 