### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export default class TrackingLink extends Component {
         // if this.windowRef is truthy we've detected Safari as the browser and
         // will use location.assign(href) to open a new tab.
         if (this.windowRef) {
-          this.windowRef.location.assign(href);
+          this.windowRef.location = href;
         } else {
           global.window.open(href, '_blank');
         }
@@ -100,7 +100,7 @@ export default class TrackingLink extends Component {
           this.windowRef.close();
         }
 
-        global.location.assign(href);
+        global.location.href = href;
       }
 
       return true;

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -50,6 +50,8 @@ test('renders children', t => {
 });
 
 test.serial('onClick() calls `onClick` prop and then calls navigateToUrl() with nativeEvent', async t => {
+  global.navigator = { userAgent: 'Safari' };
+  
   const navigateToUrlSpy = sinon.spy();
   const preventDefaultSpy = sinon.spy();
   instance.navigateToUrl = sinon.stub().returns(navigateToUrlSpy);


### PR DESCRIPTION
This fixes two failing tests.

1. The usage of `.assign()` led to this test failing: `navigateToUrl() redirects the page to the new url if there is 'href' prop`. The code has been replaced with previously working syntax. 
2. The lack of a default `userAgent` value caused this test to fail: `onClick() calls 'onClick' prop and then calls navigateToUrl() with nativeEvent`.